### PR TITLE
Corrects a typo in the Install Python Dependencies script

### DIFF
--- a/Install_dependencies_python.sh
+++ b/Install_dependencies_python.sh
@@ -28,7 +28,7 @@ sudo apt-get -y install libqtgui4
 sudo apt-get -y install libqt4-test
 
 sudo pip3 install opencv-python ArduCamDepthCamera
-sudo pip3 numpy --upgrade
+sudo pip3 install numpy --upgrade
 
 modfiy_config
 


### PR DESCRIPTION
Line 31 of the script was missing `install`, and as such it failed with pip complaining it doesn't know what the `numpy` command is. This fixes it.