### PR TITLE
rename remaining init to open

### DIFF
--- a/jetson/jetson_preview.cpp
+++ b/jetson/jetson_preview.cpp
@@ -51,7 +51,7 @@ int main()
 {
     ArducamTOFCamera tof;
     ArducamFrameBuffer *frame;
-    if (tof.init(Connection::CSI)){
+    if (tof.open(Connection::CSI)){
         std::cerr<<"initialization failed"<<std::endl;
         exit(-1);
     }

--- a/pcl_preview/preview_pointcloud.cpp
+++ b/pcl_preview/preview_pointcloud.cpp
@@ -70,7 +70,7 @@ int main()
     float *depth_ptr;
     float *amplitude_ptr;
     uint8_t *preview_ptr = new uint8_t[43200];
-    if (tof.init(Connection::CSI))
+    if (tof.open(Connection::CSI))
     {
         std::cerr << "initialization failed" << std::endl;
         exit(-1);

--- a/ros2_publisher/src/arducam/src/tof_pointcloud.cpp
+++ b/ros2_publisher/src/arducam/src/tof_pointcloud.cpp
@@ -101,7 +101,7 @@ private:
 int main(int argc, char *argv[])
 {
     rclcpp::init(argc, argv);
-    if (tof.init(Connection::CSI))
+    if (tof.open(Connection::CSI))
     {
         printf("initialize fail\n");
         exit(-1);


### PR DESCRIPTION
#46 renamed the init function in the C++ API to open. Some of the examples were not fully adapted and still contain the old function signature. This PR should also convert the remaining ones.