### PR TITLE
get config.txt path for Bookworm & earlier versions

### DIFF
--- a/Install_dependencies.sh
+++ b/Install_dependencies.sh
@@ -1,31 +1,25 @@
 #!/bin/sh
-FIND_FILE="/boot/firmware/config.txt"
 
-# modfiy_config() {
-    # modfiy config
-    # sudo sed -i "s/\(^camera_auto_detect=*\)/#\1/" /boot/config.txt
-    # sudo sed -i "s/\(^camera_auto_detect=1\)/#camera_auto_detect=0/" /boot/config.txt
-    # sudo bash -c 'echo camera_auto_detect=0 >> /boot/config.txt'
-    # sudo sed -i "s/\(^dtoverlay=*\)/#\1/" /boot/config.txt
-    # sudo bash -c 'echo dtoverlay=vc4-fkms-v3d >> /boot/config.txt'
-# }
+FIND_FILE=""
+if [ -f "/boot/firmware/config.txt" ]; then  # Bookworm
+    FIND_FILE="/boot/firmware/config.txt"
+elif [ -f "/boot/config.txt" ]; then         # Bullseye and earlier
+    FIND_FILE="/boot/config.txt"
+fi
 
-# if [ $(lsmod | grep -c arducam_pivariety) -ge 5 ]; then
-#     echo "Arducam tof camera driver already installed!"
-# else
-#     wget -O install_pivariety_pkgs.sh https://github.com/ArduCAM/Arducam-Pivariety-V4L2-Driver/releases/download/install_script/install_pivariety_pkgs.sh
-#     chmod +x install_pivariety_pkgs.sh
-#     ./install_pivariety_pkgs.sh -p kernel_driver
-# fi
+if [ "$FIND_FILE" = "" ]; then
+    echo "No config.txt file found."
+    exit 1
+fi
 
 if [ `grep -c "camera_auto_detect=1" $FIND_FILE` -ne '0' ];then
-    sudo sed -i "s/\(^camera_auto_detect=1\)/camera_auto_detect=0/" /boot/firmware/config.txt
+    sudo sed -i "s/\(^camera_auto_detect=1\)/camera_auto_detect=0/" $FIND_FILE
 fi
 if [ `grep -c "camera_auto_detect=0" $FIND_FILE` -lt '1' ];then
-    sudo bash -c 'echo camera_auto_detect=0 >> /boot/firmware/config.txt'
+    sudo bash -c "echo camera_auto_detect=0 >> $FIND_FILE"
 fi
 if [ `grep -c "dtoverlay=arducam-pivariety,media-controller=0" $FIND_FILE` -lt '1' ];then
-    sudo bash -c 'echo dtoverlay=arducam-pivariety,media-controller=0 >> /boot/firmware/config.txt'
+    sudo bash -c "echo dtoverlay=arducam-pivariety,media-controller=0 >> $FIND_FILE"
 fi
 
 if [ $(dpkg -l | grep -c arducam-tof-sdk-dev) -lt 1 ]; then

--- a/Install_dependencies.sh
+++ b/Install_dependencies.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-FIND_FILE="/boot/config.txt"
+FIND_FILE="/boot/firmware/config.txt"
 
 # modfiy_config() {
     # modfiy config
@@ -19,13 +19,13 @@ FIND_FILE="/boot/config.txt"
 # fi
 
 if [ `grep -c "camera_auto_detect=1" $FIND_FILE` -ne '0' ];then
-    sudo sed -i "s/\(^camera_auto_detect=1\)/camera_auto_detect=0/" /boot/config.txt
+    sudo sed -i "s/\(^camera_auto_detect=1\)/camera_auto_detect=0/" /boot/firmware/config.txt
 fi
 if [ `grep -c "camera_auto_detect=0" $FIND_FILE` -lt '1' ];then
-    sudo bash -c 'echo camera_auto_detect=0 >> /boot/config.txt'
+    sudo bash -c 'echo camera_auto_detect=0 >> /boot/firmware/config.txt'
 fi
 if [ `grep -c "dtoverlay=arducam-pivariety,media-controller=0" $FIND_FILE` -lt '1' ];then
-    sudo bash -c 'echo dtoverlay=arducam-pivariety,media-controller=0 >> /boot/config.txt'
+    sudo bash -c 'echo dtoverlay=arducam-pivariety,media-controller=0 >> /boot/firmware/config.txt'
 fi
 
 if [ $(dpkg -l | grep -c arducam-tof-sdk-dev) -lt 1 ]; then

--- a/Install_dependencies_python.sh
+++ b/Install_dependencies_python.sh
@@ -1,14 +1,22 @@
 #!/bin/sh
-FIND_FILE="/boot/firmware/config.txt"
+
+if [ -f "/boot/firmware/config.txt" ]; then
+    FIND_FILE="/boot/firmware/config.txt"
+elif [ -f "/boot/config.txt" ]; then
+    FIND_FILE="/boot/config.txt"
+else
+    echo "No config.txt file found."
+    exit 1
+fi
 
 if [ `grep -c "camera_auto_detect=1" $FIND_FILE` -ne '0' ];then
-    sudo sed -i "s/\(^camera_auto_detect=1\)/camera_auto_detect=0/" /boot/firmware/config.txt
+    sudo sed -i "s/\(^camera_auto_detect=1\)/camera_auto_detect=0/" $FIND_FILE
 fi
 if [ `grep -c "camera_auto_detect=0" $FIND_FILE` -lt '1' ];then
-    sudo bash -c 'echo camera_auto_detect=0 >> /boot/firmware/config.txt'
+    sudo bash -c "echo camera_auto_detect=0 >> $FIND_FILE"
 fi
 if [ `grep -c "dtoverlay=arducam-pivariety,media-controller=0" $FIND_FILE` -lt '1' ];then
-    sudo bash -c 'echo dtoverlay=arducam-pivariety,media-controller=0 >> /boot/firmware/config.txt'
+    sudo bash -c "echo dtoverlay=arducam-pivariety,media-controller=0 >> $FIND_FILE"
 fi
 
 sudo apt update

--- a/Install_dependencies_python.sh
+++ b/Install_dependencies_python.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
-FIND_FILE="/boot/config.txt"
+FIND_FILE="/boot/firmware/config.txt"
 
 if [ `grep -c "camera_auto_detect=1" $FIND_FILE` -ne '0' ];then
-    sudo sed -i "s/\(^camera_auto_detect=1\)/camera_auto_detect=0/" /boot/config.txt
+    sudo sed -i "s/\(^camera_auto_detect=1\)/camera_auto_detect=0/" /boot/firmware/config.txt
 fi
 if [ `grep -c "camera_auto_detect=0" $FIND_FILE` -lt '1' ];then
-    sudo bash -c 'echo camera_auto_detect=0 >> /boot/config.txt'
+    sudo bash -c 'echo camera_auto_detect=0 >> /boot/firmware/config.txt'
 fi
 if [ `grep -c "dtoverlay=arducam-pivariety,media-controller=0" $FIND_FILE` -lt '1' ];then
-    sudo bash -c 'echo dtoverlay=arducam-pivariety,media-controller=0 >> /boot/config.txt'
+    sudo bash -c 'echo dtoverlay=arducam-pivariety,media-controller=0 >> /boot/firmware/config.txt'
 fi
 
 sudo apt update

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This project is a use example based on arducam's depth camera. It includes basic image rendering using opencv, displaying 3D point clouds using PCL, and publishing depth camera data through the ROS2 system.
 The depth camera is the depth data obtained by calculating the phase difference based on the transmitted modulated pulse. The resolution of the camera is 240*180. Currently, it has two range modes: 2 meters and 4 meters. The measurement error is within 2 cm.
 The depth camera supports CSI and USB two connection methods, and needs an additional 5V 2A current power supply for the camera.
-### Run project on RassperyPi
-### Run the example in the exmaple folder
+### Run project on Raspberry Pi
+### Run the example in the example folder
 #### Install dependencies
 > Run in the Arducam_tof_camera folder
 ```Shell
@@ -30,7 +30,7 @@ The depth camera supports CSI and USB two connection methods, and needs an addit
 </s>
 
 ### 2.Configuration
-You need to alter the camera configuration in your /boot/config.txt file.to add dtoverlay.
+You need to alter the camera configuration in your /boot/firmware/config.txt file.to add dtoverlay.
 ```Shell
   dtoverlay=arducam-pivariety,media-controller=0
 ```


### PR DESCRIPTION
as the title says; the Install_dependencies.sh / ..python.sh scripts used pre-Bookworm config.txt paths.
This PR should use the correct path by checking for config.txt at /boot/firmware/ and /boot/ .